### PR TITLE
changed key "description-file" to "description_file" to fix issues bu…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
changed key "description-file" to "description_file" to fix issues building with setuptools v78 or higher.

Old error:
```
#8 8.790         File "/tmp/pip-build-env-behom6lj/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 629, in _enforce_underscore
#8 8.790           raise InvalidConfigError(
#8 8.790       setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
#8 8.790       [end of output]
```

See breaking change in setuptools 
https://setuptools.pypa.io/en/stable/history.html#v78-0-0